### PR TITLE
Add prepublishStep.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint . --ext .ts",
     "lint:fix": "npm run lint -- --fix",
     "test": "jest",
-    "coverage": "npm run test -- --coverage"
+    "coverage": "npm run test -- --coverage",
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "launchdarkly",


### PR DESCRIPTION
This is needed to ensure the package has built artifacts from releaser.
Later we will want to come back to this and clean the non-build artifacts out of the package.
