### PR TITLE
Feature/defaultContext

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,33 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.202.5/containers/typescript-node/.devcontainer/base.Dockerfile
+
+# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
+ARG VARIANT="16-bullseye"
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}
+
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+RUN if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then groupmod --gid $USER_GID node && usermod --uid $USER_UID --gid $USER_GID node; fi
+
+RUN if \[ ! -d /workspaces \]; then mkdir /workspaces; fi && chown -R $USER_UID:$USER_GID /workspaces
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment if you want to install an additional version of node using nvm
+# ARG EXTRA_NODE_VERSION=10
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+
+# [Optional] Uncomment if you want to install more global node packages
+# RUN su node -c "npm install -g <your-package-list -here>"
+
+RUN npm install -g npm@^7.24.2 
+
+# Install kubectl
+RUN curl -sSL -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \
+    && chmod +x /usr/local/bin/kubectl
+
+# Install Helm
+RUN curl -s https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash -
+
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,62 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.202.5/containers/typescript-node
+{
+  "name": "LaunchDarklyOpenFeature Node_server with DevContainer",
+  //runArgs is used to set container name to USERNAME.programname
+  //the reason it shows ${localEnv:USERNAME} is so that it covers both Windwos and *nix systems as frontend VSCode
+  "runArgs": [
+    "--init",
+    "--network=host"
+  ],
+  "build": {
+    "dockerfile": "Dockerfile",
+    // Update 'VARIANT' to pick a Node version: 16, 14, 12.
+    // Append -bullseye or -buster to pin to an OS version.
+    // Use -bullseye variants on local on arm64/Apple Silicon.
+    "args": {
+      "VARIANT": "16-bullseye"
+    }
+  },
+
+  "portsAttributes": {
+    "9080": {
+      "label": "Launchdarklyopenfeaturenodeserver",
+      "onAutoForward": "notify"
+    }
+  },
+  // Set *default* container specific settings.json values on container create.
+  "settings": {},
+
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": [
+    "dbaeumer.vscode-eslint",
+    "mtxr.sqltools",
+    "mtxr.sqltools-driver-pg",
+    "ms-azuretools.vscode-docker",
+    "mindaro-dev.file-downloader",
+    "github.vscode-pull-request-github",
+    "redhat.vscode-yaml"
+  ],
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // "postCreateCommand": "yarn install",
+
+  // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  "remoteUser": "node",
+  "features": {
+    "docker-from-docker": {
+      "version": "latest",
+      "moby": true
+    },
+    "kubectl-helm-minikube": "latest",
+    "git": "latest",
+    "github-cli": "latest"
+  },
+
+  // install all dependent packages after container is built and files copied into
+  "postCreateCommand": "npm install husky --save-dev && npm set-script prepare \"husky install\" && npm run prepare",
+  "postStartCommand": "npm update -g"
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,56 @@
+{
+  "configurations": [
+    {
+      "type": "pwa-node",
+      "name": "Launch via NPM",
+      "request": "launch",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run-script", "start:debug"],
+      "skipFiles": ["<node_internals>/**"],
+      "sourceMaps": true,
+      "envFile": "${workspaceFolder}/.env",
+      "cwd": "${workspaceRoot}",
+      "console": "integratedTerminal",
+      "protocol": "inspector"
+    },
+    {
+      "name": "Test via NPM test",
+      "type": "node",
+      "request": "launch",
+      "runtimeArgs": ["run-script", "test"],
+      "runtimeExecutable": "npm",
+      "skipFiles": ["<node_internals>/**"],
+      "sourceMaps": true,
+      "envFile": "${workspaceFolder}/.env",
+      "cwd": "${workspaceRoot}",
+      "console": "integratedTerminal",
+      "protocol": "inspector"
+    },
+    {
+      "name": "Test via NPM test:e2e",
+      "type": "node",
+      "request": "launch",
+      "runtimeArgs": ["run-script", "test:e2e"],
+      "runtimeExecutable": "npm",
+      "skipFiles": ["<node_internals>/**"],
+      "sourceMaps": true,
+      "envFile": "${workspaceFolder}/.env",
+      "cwd": "${workspaceRoot}",
+      "console": "integratedTerminal",
+      "protocol": "inspector"
+    },
+    {
+      "name": "Docker Node.js Launch",
+      "type": "docker",
+      "request": "launch",
+      "preLaunchTask": "docker-run: debug",
+      "platform": "node",
+      "dockerServerReadyAction": {
+        "action": "openExternally",
+
+        "pattern": "Listening on port (\\d+)",
+        "uriFormat": "http://localhost:%s"
+      }
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,35 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "docker-build",
+      "label": "docker-build",
+      "platform": "node",
+      "dockerBuild": {
+        "dockerfile": "${workspaceFolder}/Dockerfile",
+        "context": "${workspaceFolder}",
+        "pull": true
+      }
+    },
+    {
+      "type": "docker-run",
+      "label": "docker-run: release",
+      "dependsOn": ["docker-build"],
+      "platform": "node"
+    },
+    {
+      "type": "docker-run",
+      "label": "docker-run: debug",
+      "dependsOn": ["docker-build"],
+      "dockerRun": {
+        "env": {
+          "DEBUG": "*",
+          "NODE_ENV": "development"
+        }
+      },
+      "node": {
+        "enableDebugging": true
+      }
+    }
+  ]
+}

--- a/__tests__/LaunchDarklyProvider.test.ts
+++ b/__tests__/LaunchDarklyProvider.test.ts
@@ -37,6 +37,21 @@ describe('given a mock LaunchDarkly client', () => {
       .toHaveBeenCalledWith(testFlagKey, translateContext(logger, basicContext), false);
   });
 
+  it('handles correct return types for boolean variations with default context', async () => {
+    ldClient.variationDetail = jest.fn(async () => ({
+      value: true,
+      reason: {
+        kind: 'OFF',
+      },
+    }));
+    const res = await ofClient.getBooleanDetails(testFlagKey, false);
+    expect(res).toEqual({
+      flagKey: testFlagKey,
+      value: true,
+      reason: 'OFF',
+    });
+  });
+
   it('handles correct return types for boolean variations', async () => {
     ldClient.variationDetail = jest.fn(async () => ({
       value: true,
@@ -250,13 +265,13 @@ describe('given a mock LaunchDarkly client', () => {
     });
   });
 
-  it('logs information about missing keys', async () => {
-    await ofClient.getObjectDetails(testFlagKey, {}, {});
+  it('error out if context does not include etiher targetingKey or key', async () => {
+    await ofClient.getObjectDetails(testFlagKey, {}, { nonKey: 'not_a_key' });
     expect(logger.logs[0]).toEqual("The EvaluationContext must contain either a 'targetingKey' "
     + "or a 'key' and the type must be a string.");
   });
 
-  it('logs information about double keys', async () => {
+  it('logs warn information about double keys', async () => {
     await ofClient.getObjectDetails(testFlagKey, {}, { targetingKey: '1', key: '2' });
     expect(logger.logs[0]).toEqual("The EvaluationContext contained both a 'targetingKey' and a"
     + " 'key' attribute. The 'key' attribute will be discarded.");

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint:fix": "npm run lint -- --fix",
     "test": "jest",
     "coverage": "npm run test -- --coverage",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "prepare": "husky install"
   },
   "keywords": [
     "launchdarkly",
@@ -32,6 +33,7 @@
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-airbnb-typescript": "^17.0.0",
     "eslint-plugin-import": "^2.26.0",
+    "husky": "^8.0.3",
     "jest": "^27.5.1",
     "jest-junit": "^14.0.1",
     "launchdarkly-node-server-sdk": "7.x",

--- a/src/translateContext.ts
+++ b/src/translateContext.ts
@@ -113,6 +113,10 @@ export default function translateContext(
 ): LDContext {
   let finalKind = 'user';
 
+  // context is absent then use default anonymous context
+  if (Object.entries(evalContext).length === 0) {
+    return { key: 'OpenFeature default', anonymous: true } as LDContext;
+  }
   // A multi-context.
   if (evalContext.kind === 'multi') {
     return Object.entries(evalContext)


### PR DESCRIPTION
**Requirements**

- [ X] I have added test coverage for new or changed functionality
- [ X] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ X] I have validated my changes against all supported platform versions

**Related issues**
N/A
Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

When openfeatureClient.get<T>Value functions are called, `context` was mandatory. However, in many use cases, context was either irrelevant or not available, we would like to be able to call the get<T>Value without providing context.  

A default context with {key:"OpenFeature default", anonymous:true} is added when context was not provided when calling the get functions. 

**Describe alternatives you've considered**

Use the setTransactionContextPropagator function to set default transaction level context.  However that is an experimental feature of OpenFeature and is not reliable enough for actual production use.  

**Additional context**

Add any other context about the pull request here.
