### PR TITLE
fix: unit test failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 coverage/
 reports/
 docs/
+.idea

--- a/__tests__/LaunchDarklyProvider.test.ts
+++ b/__tests__/LaunchDarklyProvider.test.ts
@@ -45,7 +45,7 @@ describe('given a mock LaunchDarkly client', () => {
       },
     }));
     const res = await ofClient.getBooleanDetails(testFlagKey, false, basicContext);
-    expect(res).toEqual({
+    expect(res).toMatchObject({
       flagKey: testFlagKey,
       value: true,
       reason: 'OFF',
@@ -60,7 +60,7 @@ describe('given a mock LaunchDarkly client', () => {
       },
     }));
     const res = await ofClient.getBooleanDetails(testFlagKey, false, basicContext);
-    expect(res).toEqual({
+    expect(res).toMatchObject({
       flagKey: testFlagKey,
       value: false,
       reason: 'ERROR',
@@ -92,7 +92,7 @@ describe('given a mock LaunchDarkly client', () => {
       },
     }));
     const res = await ofClient.getStringDetails(testFlagKey, 'default', basicContext);
-    expect(res).toEqual({
+    expect(res).toMatchObject({
       flagKey: testFlagKey,
       value: 'good',
       reason: 'OFF',
@@ -107,7 +107,7 @@ describe('given a mock LaunchDarkly client', () => {
       },
     }));
     const res = await ofClient.getStringDetails(testFlagKey, 'default', basicContext);
-    expect(res).toEqual({
+    expect(res).toMatchObject({
       flagKey: testFlagKey,
       value: 'default',
       reason: 'ERROR',
@@ -139,7 +139,7 @@ describe('given a mock LaunchDarkly client', () => {
       },
     }));
     const res = await ofClient.getNumberDetails(testFlagKey, 0, basicContext);
-    expect(res).toEqual({
+    expect(res).toMatchObject({
       flagKey: testFlagKey,
       value: 17,
       reason: 'OFF',
@@ -154,7 +154,7 @@ describe('given a mock LaunchDarkly client', () => {
       },
     }));
     const res = await ofClient.getNumberDetails(testFlagKey, 0, basicContext);
-    expect(res).toEqual({
+    expect(res).toMatchObject({
       flagKey: testFlagKey,
       value: 0,
       reason: 'ERROR',
@@ -186,7 +186,7 @@ describe('given a mock LaunchDarkly client', () => {
       },
     }));
     const res = await ofClient.getObjectDetails(testFlagKey, {}, basicContext);
-    expect(res).toEqual({
+    expect(res).toMatchObject({
       flagKey: testFlagKey,
       value: { some: 'value' },
       reason: 'OFF',
@@ -201,7 +201,7 @@ describe('given a mock LaunchDarkly client', () => {
       },
     }));
     const res = await ofClient.getObjectDetails(testFlagKey, {}, basicContext);
-    expect(res).toEqual({
+    expect(res).toMatchObject({
       flagKey: testFlagKey,
       value: {},
       reason: 'ERROR',
@@ -225,7 +225,7 @@ describe('given a mock LaunchDarkly client', () => {
       },
     }));
     const res = await ofClient.getObjectDetails(testFlagKey, {}, basicContext);
-    expect(res).toEqual({
+    expect(res).toMatchObject({
       flagKey: testFlagKey,
       value: { yes: 'no' },
       reason: 'ERROR',
@@ -242,7 +242,7 @@ describe('given a mock LaunchDarkly client', () => {
       },
     }));
     const res = await ofClient.getObjectDetails(testFlagKey, {}, basicContext);
-    expect(res).toEqual({
+    expect(res).toMatchObject({
       flagKey: testFlagKey,
       value: { yes: 'no' },
       variant: '22',


### PR DESCRIPTION
It looks like gonfalon may have updated the eval response and nown all unit tests are failing with two additional fields `flagMetadata` and `variant`. I see that `variant` is part of the open feature [spec](https://openfeature.dev/docs/reference/concepts/evaluation-api#detailed-evaluation), but `flagMetadata` is not. This pr takes the easy way out and changes the assertion to match a subset of the json response, but I'm not sure if this is the original intent of these tests.

```sh
 expect(received).toEqual(expected) // deep equality

    - Expected  - 0
    + Received  + 2

      Object {
        "flagKey": "a-key",
    +   "flagMetadata": Object {},
        "reason": "OFF",
        "value": Object {
          "some": "value",
        },
    +   "variant": undefined,
      }

```
