### PR TITLE
feat: Update minimum node version, and update dev dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@launchdarkly/openfeature-node-server",
   "version": "1.0.0",
+  "engines": {
+    "node": ">=18"
+  },
   "description": "LaunchDarkly OpenFeature provider for node.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -32,16 +35,16 @@
   "devDependencies": {
     "@launchdarkly/node-server-sdk": "9.x",
     "@openfeature/server-sdk": "^1.14.0",
-    "@types/jest": "^27.4.1",
+    "@types/jest": "^29.5.14",
     "@typescript-eslint/eslint-plugin": "^5.22.0",
     "@typescript-eslint/parser": "^5.22.0",
     "eslint": "^8.14.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-airbnb-typescript": "^17.0.0",
     "eslint-plugin-import": "^2.26.0",
-    "jest": "^27.5.1",
-    "jest-junit": "^14.0.1",
-    "ts-jest": "^27.1.4",
+    "jest": "^29.7.0",
+    "jest-junit": "^16.0.0",
+    "ts-jest": "^29.2.6",
     "typedoc": "^0.25.13",
     "typescript": "^4.7.4"
   }


### PR DESCRIPTION
Unit tests were failing with Jest error `SyntaxError: Unexpected token 'export'`

This PR bumps minimum supported Node version to 18 and updates `jest` and `ts-jest` packages to latest in order to solve the problem.