### PR TITLE
docs: adding repo moved notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# This repository has moved to [js-core](https://github.com/launchdarkly/js-core/tree/main/packages/sdk/openfeature-node-server).
+
+The `@launchdarkly/openfeature-node-server` source has moved to the
+[js-core repository](https://github.com/launchdarkly/js-core/tree/main/packages/sdk/openfeature-node-server). All future releases will be made from that repository. Please file issues and feature requests in the [js-core issue tracker](https://github.com/launchdarkly/js-core/issues?q=is%3Aissue+is%3Aopen+label%3A%22package%3A+sdk%2Fopenfeature-node-server%22+sort%3Aupdated-desc).
+
 # LaunchDarkly OpenFeature provider for the Server-Side SDK for Node.js
 
 This provider allows for using LaunchDarkly with the OpenFeature JS SDK.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or build impact.
> 
> **Overview**
> Adds a **repository moved** notice at the top of `README.md` directing readers to the [js-core](https://github.com/launchdarkly/js-core/tree/main/packages/sdk/openfeature-node-server) monorepo for `@launchdarkly/openfeature-node-server` source, future releases, and issue tracking.
> 
> The rest of the README is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00c90d2ceea66dd0a5300e8ff7f127ba74c5c55b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->